### PR TITLE
Optimize Object::notification method performance

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -863,16 +863,25 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 void Object::notification(int p_notification, bool p_reversed) {
 	if (p_reversed) {
+		_notification_fast<true>(p_notification);
+	} else {
+		_notification_fast<false>(p_notification);
+	}
+}
+
+template <bool t_reversed>
+void Object::_notification_fast(int p_notification) {
+	if constexpr (t_reversed) {
 		if (script_instance) {
-			script_instance->notification(p_notification, p_reversed);
+			script_instance->notification(p_notification, t_reversed);
 		}
 	} else {
-		_notificationv(p_notification, p_reversed);
+		_notificationv(p_notification, t_reversed);
 	}
 
 	if (_extension) {
 		if (_extension->notification2) {
-			_extension->notification2(_extension_instance, p_notification, static_cast<GDExtensionBool>(p_reversed));
+			_extension->notification2(_extension_instance, p_notification, static_cast<GDExtensionBool>(t_reversed));
 #ifndef DISABLE_DEPRECATED
 		} else if (_extension->notification) {
 			_extension->notification(_extension_instance, p_notification);
@@ -880,11 +889,11 @@ void Object::notification(int p_notification, bool p_reversed) {
 		}
 	}
 
-	if (p_reversed) {
-		_notificationv(p_notification, p_reversed);
+	if constexpr (t_reversed) {
+		_notificationv(p_notification, t_reversed);
 	} else {
 		if (script_instance) {
-			script_instance->notification(p_notification, p_reversed);
+			script_instance->notification(p_notification, t_reversed);
 		}
 	}
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -676,6 +676,9 @@ private:
 
 	Object(bool p_reference);
 
+	template <bool t_reversed>
+	void _notification_fast(int p_notification);
+
 protected:
 	_FORCE_INLINE_ bool _instance_binding_reference(bool p_reference) {
 		bool can_die = true;


### PR DESCRIPTION
This commit optimizes the Object::notification method by separating the logic for forward and reverse notifications into dedicated inline functions. This improves code clarity and enables the compiler to perform more effective optimizations, resulting in a performance improvement.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
