### PR TITLE
Optimize shared texture creation

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -903,7 +903,7 @@ RID RenderingDevice::texture_create_shared(const TextureView &p_view, RID p_with
 
 	// Create view.
 
-	Texture texture = *src_texture;
+	Texture texture = src_texture->duplicate_as_shared_texture();
 	texture.shared_fallback = nullptr;
 
 	RDD::TextureView tv;
@@ -959,8 +959,6 @@ RID RenderingDevice::texture_create_shared(const TextureView &p_view, RID p_with
 	}
 
 	ERR_FAIL_COND_V(!texture.driver_id, RID());
-
-	texture.slice_trackers.clear();
 
 	if (texture.draw_tracker != nullptr) {
 		texture.draw_tracker->reference_count++;
@@ -1055,7 +1053,7 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 		slice_layers = 6;
 	}
 
-	Texture texture = *src_texture;
+	Texture texture = src_texture->duplicate_as_shared_texture();
 	texture.shared_fallback = nullptr;
 
 	get_image_format_required_size(texture.format, texture.width, texture.height, texture.depth, p_mipmap + 1, &texture.width, &texture.height);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -264,6 +264,41 @@ public:
 		int32_t transfer_worker_index = -1;
 		uint64_t transfer_worker_operation = 0;
 
+		Texture duplicate_as_shared_texture() const {
+			Texture texture;
+			texture.driver_id = driver_id;
+			texture.type = type;
+			texture.format = format;
+			texture.samples = samples;
+			texture.slice_type = slice_type;
+			texture.slice_rect = slice_rect;
+			texture.width = width;
+			texture.height = height;
+			texture.depth = depth;
+			texture.layers = layers;
+			texture.mipmaps = mipmaps;
+			texture.usage_flags = usage_flags;
+			texture.base_mipmap = base_mipmap;
+			texture.base_layer = base_layer;
+
+			texture.allowed_shared_formats = allowed_shared_formats;
+
+			texture.is_resolve_buffer = is_resolve_buffer;
+			texture.has_initial_data = has_initial_data;
+
+			texture.read_aspect_flags = read_aspect_flags;
+			texture.barrier_aspect_flags = barrier_aspect_flags;
+			texture.bound = bound;
+			texture.owner = owner;
+
+			texture.draw_tracker = draw_tracker;
+			// `slice_trackers` is only used by the owner and it can be expensive to copy.
+			texture.shared_fallback = shared_fallback;
+			texture.transfer_worker_index = transfer_worker_index;
+			texture.transfer_worker_operation = transfer_worker_operation;
+			return texture;
+		}
+
 		RDD::TextureSubresourceRange barrier_range() const {
 			RDD::TextureSubresourceRange r;
 			r.aspect = barrier_aspect_flags;


### PR DESCRIPTION
This commit removes an unnecessary copy of `Texture::slice_trackers`, as it is always cleared afterward.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
